### PR TITLE
client: don't try to restart samba service

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -53,7 +53,6 @@
     state: installed
     update_cache: yes
   when: samba_cl_packages | length > 0
-  notify: restart samba
 
 - name: create /etc/krb5.conf
   template:


### PR DESCRIPTION
samba service is not available on client nodes, hence an attempt to restart
them is deemed to fail:

TASK [samba : restart samba] ***************************************************************************
fatal: [cl1]: FAILED! => {"changed": false, "msg": "Could not find the requested service samba: host"}
fatal: [cl2]: FAILED! => {"changed": false, "msg": "Could not find the requested service samba: host"}
fatal: [cl0]: FAILED! => {"changed": false, "msg": "Could not find the requested service samba: host"}

Closes: BaseALT/infra #7