### PR TITLE
Avoid failures if /etc/net/ifaces does not exist

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -24,6 +24,12 @@
   when: nm_conf_is.changed == false
   notify: restart networkmanager
 
+- name: create /etc/net/ifaces/eth0
+  file:
+    path: /etc/net/ifaces/eth0
+    state: directory
+    mode: 0755
+
 - name: enable eth0
   lineinfile:
     path: /etc/net/ifaces/eth0/options
@@ -31,6 +37,7 @@
     line: 'DISABLED=no'
     backrefs: yes
     state: present
+    create: true
   register: net_conf_is
   changed_when: net_conf_is.changed
   notify: restart network

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
     when: item not in vars
     with_items: "{{ samba_dc_required_vars }}"
 
+  - name: install openresolv and etcnet
+    apt_rpm: pkg=openresolv,etcnet state=present
+
   - name: install samba DC common packages
     apt_rpm:
       pkg: "{{samba_dc_common_packages | join(',')}}"

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -67,12 +67,8 @@
   when: res.stat.exists == False
 
 - name: remove all resolve.conf on interfaces
-  block:
-    - shell: find /etc/net/ifaces/ -name 'resolv.conf'
-      register: res
-      changed_when: false
-    - file: path="{{item}}" state=absent
-      with_items: "{{res.stdout_lines}}"
+  shell: >
+    if [ -d /etc/net/ifaces ]; then find /etc/net/ifaces -name 'resolv.conf' -delete; fi
 
 - name: enable samba service
   service:


### PR DESCRIPTION
ALTLinux installations without etcnet are perfectly possible and valid (one could manage network with systemd, or NetworkManager). For instance, the official p8 cloud image [1] is built exactly this way. Therefore install explicitly install `etcnet` and `openresolv` packages, and check if `/etc/net/ifaces` exists before using it 

[1] http://nightly.altlinux.org/p8/release/alt-p8-cloud-20180612-x86_64.img.xz

Closes: #7