### PR TITLE
Made DNS configuration more robust, and support systemd-networkd

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -44,11 +44,6 @@
   changed_when: net_conf_is.changed
   notify: restart network
 
-- name: set master as an only nameserver
-  template:
-    src: resolv.conf.j2
-    dest: /etc/net/ifaces/eth0/resolv.conf
-  notify: restart network
 
 - meta: flush_handlers
 

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -33,7 +33,15 @@
     - nm_conf_is.changed == false
   notify: restart networkmanager
 
-- name: enable eth0
+- name: check if /etc/net/ifaces/eth0 exists
+  stat: path=/etc/net/ifaces/eth0
+  register: ifaces_eth0_st
+  failed_when: false
+
+- set_fact:
+    managed_by_etcnet: "{{ ifaces_eth0_st.stat.exists and ifaces_eth0_st.stat.isdir }}"
+
+- name: enable eth0 (etcnet)
   lineinfile:
     path: /etc/net/ifaces/eth0/options
     regexp: '^DISABLED='
@@ -41,7 +49,8 @@
     backrefs: yes
     state: present
   register: net_conf_is
-  changed_when: net_conf_is.changed
+  changed_when: managed_by_etcnet|bool and net_conf_is.changed
+  when: managed_by_etcnet|bool
   notify: restart network
 
 

--- a/tasks/dns.yml
+++ b/tasks/dns.yml
@@ -1,8 +1,8 @@
 ---
 
 - name: purge other resolv.conf`s
-  shell: |
-    find /etc/net/ifaces/*/resolv.conf -rm
+  command: >
+    find /etc/net/ifaces -name resolv.conf -delete
   register: res
   changed when: res.rc == 0
   failed_when: false

--- a/tasks/dns.yml
+++ b/tasks/dns.yml
@@ -20,3 +20,11 @@
   service:
     name: network
     state: restarted
+
+- name: validate /etc/resolv.conf
+  command: >
+    grep -q -e 'nameserver {{ item }}' /etc/resolv.conf
+  with_items:
+    - "{{ samba_master_address }}"
+    - "{{ samba_dns_forward }}"
+

--- a/tasks/dns.yml
+++ b/tasks/dns.yml
@@ -12,6 +12,28 @@
     src: resolv.conf.j2
     dest: /etc/net/ifaces/lo/resolv.conf
 
+- name: check if systemd-networkd is installed
+  command: >
+    rpm -q systemd-networkd
+  register: systemd_networkd_present
+  failed_when: false
+
+- name: create /etc/systemd/resolved.conf.d
+  file:
+    path: /etc/systemd/resolved.conf.d
+    state: directory
+    mode: 0755
+
+- name: set master DC as the 1st nameserver, systemd-resolved
+  template:
+    src: resolved-conf.d-samba.j2
+    dest: /etc/systemd/resolved.conf.d/samba.conf
+    mode: 0644
+
+- name: restart systemd-resolved
+  service: name=systemd-resolved state=restarted
+  when: systemd_networkd_present.rc == 0
+
 - name: black magic
   shell: update_chrooted all
   changed_when: false
@@ -20,6 +42,8 @@
   service:
     name: network
     state: restarted
+  with_sequence: start=1 end=2
+# XXX: resolvconf updates /etc/resolv.conf only on 2nd run
 
 - name: validate /etc/resolv.conf
   command: >

--- a/tasks/dns.yml
+++ b/tasks/dns.yml
@@ -1,0 +1,22 @@
+---
+
+- name: purge other resolv.conf`s
+  shell: |
+    find /etc/net/ifaces/*/resolv.conf -rm
+  register: res
+  changed when: res.rc == 0
+  failed_when: false
+
+- name: set master DC as the 1st nameserver
+  template:
+    src: resolv.conf.j2
+    dest: /etc/net/ifaces/lo/resolv.conf
+
+- name: black magic
+  shell: update_chrooted all
+  changed_when: false
+
+- name: restart network service
+  service:
+    name: network
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,19 @@
     when: item not in vars
     with_items: "{{ samba_dc_required_vars }}"
 
+  - name: install openresolv and etcnet
+    apt_rpm: pkg=openresolv,etcnet state=present
+    register: openresolv_install
+
+  # XXX: touching /etc/resolv.conf might start altlinux-openresolv.service,
+  # (if it hasn't been started before, i.e. if the openresolv package haven't
+  # been installed before applying this role). altlinux-openresolv overwrites
+  # modifications of /etc/resolv.conf done by this role. Therefore explicitly
+  # start altlinux-openresolv before adjusting /etc/resolv.conf
+  - name: start altlinux-openresolv
+    service: name=altlinux-openresolv state=started
+    when: openresolv_install.changed|bool
+
   - name: install samba DC common packages
     apt_rpm:
       pkg: "{{samba_dc_common_packages | join(',')}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,26 +38,8 @@
     shell: hostname "{{inventory_hostname_short}}.{{samba_realm}}"
     changed_when: false
 
-  - name: purge other resolv.conf`s
-    shell: |
-      find /etc/net/ifaces/*/resolv.conf -rm
-    register: res
-    changed when: res.rc == 0
-    failed_when: false
+  - include: dns.yml
 
-  - name: set master as an only nameserver
-    template:
-      src: resolv.conf.j2
-      dest: /etc/net/ifaces/lo/resolv.conf
-
-  - name: black magick
-    shell: update_chrooted all
-    changed_when: false
-
-  - name: restart network service
-    service:
-      name: network
-      state: restarted
   when: samba_flavor != 'gen_test_env'
 
 - name: deploy DC master

--- a/templates/resolved-conf.d-samba.j2
+++ b/templates/resolved-conf.d-samba.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+[Resolve]
+DNS={{ samba_master_address }} {{ samba_dns_forward }}
+Domains={{ samba_realm|lower }}


### PR DESCRIPTION
In addition to supporting systemd-resolved this PR makes DNS configuration more fool proof, i.e. DNS related tasks now

- Skip unnecessary network reconfiguration on clients
- Remove `resolv.conf` files from `/etc/net/ifaces/IFACE` directories for real
- Perform basic validation of  the `/etc/resolv.conf` file (check that the master DC is listed)
- Don't fail if `openresolv` and/or `etcnet` packages are not installed
- Don't reconfigure `eth0` interface if it is **not** managed by `etcnet`
