### PR TITLE
client: fixed interaction of resolvconf and NetworkManager

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -55,6 +55,7 @@
 - name: update resolver, step 1
   command: resolvconf -d NetworkManager
   when: networkmanager_present.rc == 0
+  failed_when: false
   changed_when: false
 
 - name: update resolver, step 2


### PR DESCRIPTION
`resolvconf -d NetworkManager` might fail if the machine hasn't received
any DNS settings update from the NetworkManager yet (for instance if
the machine in question has been just bootstrapped by vargrant).
Ignore the exit code of `resolvconf -d` to avoid the problem.