### PR TITLE
Optionally set samba log level during deployment

### DIFF
--- a/templates/smb.conf.client.j2
+++ b/templates/smb.conf.client.j2
@@ -9,6 +9,11 @@
 
 	idmap config * : range = 10000-20000000
 	idmap config * : backend = tdb
+{% if samba_log_level is defined %}
+	log level = {{ samba_log_level }}
+	timestamp logs = yes
+	debug hires timestamp = yes
+{% endif %}
 [homes]
 	comment = Home Directories
 	browseable = no

--- a/templates/smb.conf.master.j2
+++ b/templates/smb.conf.master.j2
@@ -10,6 +10,11 @@
 	interfaces = lo {{samba_master_address}}
 	kerberos method = dedicated keytab
 	dedicated keytab file = /etc/krb5.keytab
+{% if samba_log_level is defined %}
+	log level = {{ samba_log_level }}
+	timestamp logs = yes
+	debug hires timestamp = yes
+{% endif %}
 [netlogon]
 	path = /var/lib/samba/sysvol/{{samba_domain}}/scripts
 	read only = No

--- a/templates/smb.conf.replica.j2
+++ b/templates/smb.conf.replica.j2
@@ -10,6 +10,11 @@
 	interfaces = lo {{samba_address}}
 	kerberos method = dedicated keytab
 	dedicated keytab file = /etc/krb5.keytab
+{% if samba_log_level is defined %}
+	log level = {{ samba_log_level }}
+	timestamp logs = yes
+	debug hires timestamp = yes
+{% endif %}
 [netlogon]
 	path = /var/lib/samba/sysvol/{{samba_domain}}/scripts
 	read only = No


### PR DESCRIPTION
In order to enable verbose logging one can set `samba_log_level`
variable in the group or host variables. Although one can adjust
the /etc/samba/smb.conf with ansible after applying the `samba`
role, however

- it's sort of annoying,
- and most importantly one might want to debug the join procedure
  itself, thus setting the log level *after* the role has been
  applied is of no use (it's too late: clients have already tried
  to join, and there's no easy way to revert both clients and DCs
  to the pre-join state)

Thus the patch makes collecting debug logs easier (especially if
one wants to debug the join procedure itself).